### PR TITLE
Update monitors to be more generic

### DIFF
--- a/docs/challenged_proposal.md
+++ b/docs/challenged_proposal.md
@@ -1,5 +1,5 @@
 ## Purpose
-The `challenged_proposal.gate` monitor is designed to ensure the liveness of the fault proof system. It detects situations where the Challenger (`cbChallenger`), assumed to be operating honestly, challenges a state output root proposed by the Proposer (`cbProposer`), who is also assumed to be honest.
+The `challenged_proposal.gate` monitor is designed to ensure the liveness of the fault proof system. It detects situations where the Challenger (`honestChallenger`), assumed to be operating honestly, challenges a state output root proposed by the Proposer (`honestProposer`), who is also assumed to be honest.
 
 Such an event indicates a critical issue—potentially a bug in the fault proof smart contracts or offchain components—that could compromise the system's ability to progress. Detecting this scenario promptly is essential to maintain the integrity and reliability of the network.
 
@@ -7,10 +7,10 @@ Such an event indicates a critical issue—potentially a bug in the fault proof 
 
 ### How It Works
 
-- **Monitoring Dispute Games**: The monitor observes active dispute games involving state output roots proposed by the `cbProposer`.
+- **Monitoring Dispute Games**: The monitor observes active dispute games involving state output roots proposed by the `honestProposer`.
 
 - **Identifying Claims**:
-  - **Root Claim**: The initial claim in a dispute game made by the `cbProposer`.
+  - **Root Claim**: The initial claim in a dispute game made by the `honestProposer`.
   - **Subsequent Moves**: Claims made by participants in response to the root claim.
 
 - **Analyzing Challenges**:
@@ -18,10 +18,10 @@ Such an event indicates a critical issue—potentially a bug in the fault proof 
     - **Even `parentIndex`**: Represents an attack against the parent claim.
     - **Odd `parentIndex`**: Represents a defense of the parent claim.
 
-  The monitor checks if the `cbChallenger` has made an attack (even `parentIndex`) against the root claim proposed by the `cbProposer`.
+  The monitor checks if the `honestChallenger` has made an attack (even `parentIndex`) against the root claim proposed by the `honestProposer`.
 
 - **Triggering Alerts**:
-  - If such an attack is detected, it implies that the `cbChallenger` is challenging a correct proposal from the `cbProposer`.
+  - If such an attack is detected, it implies that the `honestChallenger` is challenging a correct proposal from the `honestProposer`.
   - This situation indicates a potential issue affecting the system's liveness.
   - The monitor raises an alert for immediate investigation.
 
@@ -33,6 +33,6 @@ Such an event indicates a critical issue—potentially a bug in the fault proof 
 
 ## Parameters
 
-- `cbChallenger`: Address of the Challenger.
-- `cbProposer` : Address of the Proposer.
+- `honestChallenger`: Address of the Challenger.
+- `honestProposer` : Address of the Proposer.
 - `disputeGame`: Address of the dispute game contract being monitored.

--- a/docs/challenger_loses.md
+++ b/docs/challenger_loses.md
@@ -1,18 +1,18 @@
 ## Purpose
 
-The `challenger_loses.gate` monitor ensures the **safety** of the fault proof system by detecting situations where the Challenger (`cbChallenger`), assumed to be operating honestly, loses a dispute game or any subgame within the dispute game that they should have won. Since the `cbChallenger` acts in good faith, a game indicates a critical issue—possibly a logic flaw in the dispute game contracts or offchain components—that could compromise the integrity and security of the network.
+The `challenger_loses.gate` monitor ensures the **safety** of the fault proof system by detecting situations where the Challenger (`honestChallenger`), assumed to be operating honestly, loses a dispute game or any subgame within the dispute game that they should have won. Since the `honestChallenger` acts in good faith, a game indicates a critical issue—possibly a logic flaw in the dispute game contracts or offchain components—that could compromise the integrity and security of the network.
 
 ## Technical Overview
 
 ### How It Works
 
-1. **Monitoring Dispute Resolutions**: The monitor observes dispute games and its subgames involving the `cbChallenger` and checks for the resolution statuses.
+1. **Monitoring Dispute Resolutions**: The monitor observes dispute games and its subgames involving the `honestChallenger` and checks for the resolution statuses.
 
 2. **Identifying Challenger's Role**:
    
-   - **As a Challenger**: When the `cbChallenger` initiates a challenge against an incorrect state output root.
+   - **As a Challenger**: When the `honestChallenger` initiates a challenge against an incorrect state output root.
    
-   - **As a Defender**: When the `cbChallenger` defends a correct state output root against challenges.
+   - **As a Defender**: When the `honestChallenger` defends a correct state output root against challenges.
 
 3. **Analyzing Outcomes**:
    
@@ -20,15 +20,15 @@ The `challenger_loses.gate` monitor ensures the **safety** of the fault proof sy
      - **Defender Wins (Status 1)**: Indicates the defender won the dispute.
      - **Challenger Wins (Status 2)**: Indicates the challenger won the dispute.
 
-   - It also examines all moves (subgames) made in the dispute game to identify the actions taken by the `cbChallenger`.
+   - It also examines all moves (subgames) made in the dispute game to identify the actions taken by the `honestChallenger`.
 
 4. **Detecting Anomalies**:
    
-   - **Challenger Loses as Challenger**: If the `cbChallenger` initiated the challenge but the dispute resolves with the defender winning, this suggests an incorrect outcome.
+   - **Challenger Loses as Challenger**: If the `honestChallenger` initiated the challenge but the dispute resolves with the defender winning, this suggests an incorrect outcome.
    
-   - **Challenger Loses as Defender**: If the `cbChallenger` defended a correct claim but the dispute resolves with the challenger winning, this indicates a problem.
+   - **Challenger Loses as Defender**: If the `honestChallenger` defended a correct claim but the dispute resolves with the challenger winning, this indicates a problem.
 
-   - **Lost Subgames**: The monitor also checks if the `cbChallenger` lost any subgames within the dispute game, which should not happen if the challenger is acting honestly.
+   - **Lost Subgames**: The monitor also checks if the `honestChallenger` lost any subgames within the dispute game, which should not happen if the challenger is acting honestly.
 
 5. **Triggering Alerts**:
 
@@ -46,6 +46,6 @@ The `challenger_loses.gate` monitor ensures the **safety** of the fault proof sy
 
 ## Parameters
 
-- `cbChallenger`: Address of the Challenger.
+- `honestChallenger`: Address of the Challenger.
 - `disputeGame`: Address of the dispute game contract being monitored.
 

--- a/docs/eth_deficit.md
+++ b/docs/eth_deficit.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-The `eth_deficit.gate` monitor ensures the **safety** and integrity of the fault proof system by detecting any deficits of ETH in the `DelayedWETH` contract associated with the specified dispute game. The `DelayedWETH` contract holds the ETH bonds deposited by participants in dispute games. A deficit indicates that more ETH has been withdrawn than should be allowed, potentially due to bugs in bond accounting or dispute game resolution, which can result in financial losses for honest participants. Note this monitor tracks deficits in relation to the Challenger (`cbChallenger`), who is assumed to be operating honestly and participating in every dispute game as necessary.
+The `eth_deficit.gate` monitor ensures the **safety** and integrity of the fault proof system by detecting any deficits of ETH in the `DelayedWETH` contract associated with the specified dispute game. The `DelayedWETH` contract holds the ETH bonds deposited by participants in dispute games. A deficit indicates that more ETH has been withdrawn than should be allowed, potentially due to bugs in bond accounting or dispute game resolution, which can result in financial losses for honest participants. Note this monitor tracks deficits in relation to the Challenger (`honestChallenger`), who is assumed to be operating honestly and participating in every dispute game as necessary.
 
 ## Technical Overview
 
@@ -10,9 +10,9 @@ The `eth_deficit.gate` monitor ensures the **safety** and integrity of the fault
 
    - **DelayedWETH Address**: Retrieves the `DelayedWETH` contract address associated with the specific `disputeGame`.
 
-   - **Challenger's Claim Credit (`claimCredit`)**: The amount of ETH that the Challenger (`cbChallenger`) can currently claim from the `disputeGame`.
+   - **Challenger's Claim Credit (`claimCredit`)**: The amount of ETH that the Challenger (`honestChallenger`) can currently claim from the `disputeGame`.
 
-   - **Challenger's Total Credit (`totalCredit`)**: The total amount of ETH that has been unlocked for the `cbChallenger` in the `DelayedWETH` contract.
+   - **Challenger's Total Credit (`totalCredit`)**: The total amount of ETH that has been unlocked for the `honestChallenger` in the `DelayedWETH` contract.
 
    - **Dispute Game's ETH Balance (`ethBalanceDisputeGame`)**: The total amount of ETH held in the `DelayedWETH` contract for the `disputeGame`.
 
@@ -47,4 +47,4 @@ The `eth_deficit.gate` monitor ensures the **safety** and integrity of the fault
 ## Parameters
 
 - `disputeGame`: Address of the dispute game contract being monitored.
-- `cbChallenger`: Address of the Challenger.
+- `honestChallenger`: Address of the Challenger.

--- a/monitors/challenged_proposal.gate
+++ b/monitors/challenged_proposal.gate
@@ -1,8 +1,8 @@
 use Call, Events, Contains, Range, Len from hexagate;
 
 param disputeGame: address;
-param cbProposer: address;
-param cbChallenger: address;
+param honestProposer: address;
+param honestChallenger: address;
 
 // Source to retrieve `Move` events from the specified dispute game contract
 source moveEvents: list<tuple<integer, bytes, address>> = Events {
@@ -43,9 +43,9 @@ source attackClaimParentIndices: list<integer> = Range {
 //      by checking the parentIndex of the claim. If the parentIndex is 0 or an even number, then the claim is an
 //      attack ultimately against the root claim, no matter the depth.
 source challengerAttacks: list<boolean> = [
-    (claim[2] == cbChallenger) and Contains { sequence: attackClaimParentIndices, item: claim[0] }
+    (claim[2] == honestChallenger) and Contains { sequence: attackClaimParentIndices, item: claim[0] }
     for claim in claimData
-    if (rootClaimProposer == cbProposer)
+    if (rootClaimProposer == honestProposer)
 ];
 
 // Trigger an alert when an attack by the CB challenger on a state output root proposed by the CB proposer is detected

--- a/monitors/challenger_loses.gate
+++ b/monitors/challenger_loses.gate
@@ -1,7 +1,7 @@
 use Call, Calls, Events, HistoricalEvents, Contains, Len, Range, FilterAddressesInTrace from hexagate;
 
 // Parameters to be passed
-param cbChallenger: address;
+param honestChallenger: address;
 param disputeGame: address;
 
 // Filter to only run this invariant if the disputeGame address is in the trace
@@ -46,27 +46,27 @@ source oddParentIndices: list<integer> = Range {
     step: 2
 };
 
-// Filter the historical events where the claimant is cbChallenger and the parentIndex is even (challenge move)
+// Filter the historical events where the claimant is honestChallenger and the parentIndex is even (challenge move)
 source challengeMoves: list<tuple<integer, bytes, address>> = [
     event
     for event in historicalMoveEvents
-    if (event[2] == cbChallenger) and Contains { sequence: evenParentIndices, item: event[0] }
+    if (event[2] == honestChallenger) and Contains { sequence: evenParentIndices, item: event[0] }
 ];
 
-// Filter the historical events where the claimant is cbChallenger and the parentIndex is odd (defense move)
+// Filter the historical events where the claimant is honestChallenger and the parentIndex is odd (defense move)
 source defenseMoves: list<tuple<integer, bytes, address>> = [
     event
     for event in historicalMoveEvents
-    if (event[2] == cbChallenger) and Contains { sequence: oddParentIndices, item: event[0] }
+    if (event[2] == honestChallenger) and Contains { sequence: oddParentIndices, item: event[0] }
 ];
 
-// Check if the CB challenger lost as a challenger
+// Check if the challenger lost as a challenger
 source challengerLost: boolean = (resolveStatus == 2) and (Len { sequence: challengeMoves } > 0);
 
-// Check if the CB challenger lost as a defender
+// Check if the challenger lost as a defender
 source defenderLost: boolean = (resolveStatus == 1) and (Len { sequence: defenseMoves } > 0);
 
-// Check if the CB challenger lost any subgames as well
+// Check if the challenger lost any subgames as well
 source claimResults: list<tuple<integer,address,address,integer,bytes,integer,integer>> = [
     Call {
         contract: disputeGame,
@@ -79,23 +79,23 @@ source claimResults: list<tuple<integer,address,address,integer,bytes,integer,in
 source lostSubgames: list<boolean> = [
     subgame[1] != zeroAddr ? true : false
     for subgame in claimResults
-    if (subgame[2] == cbChallenger)
+    if (subgame[2] == honestChallenger)
 ];
 
-// Invariant to trigger an alert if the CB challenger lost as a challenger
+// Invariant to trigger an alert if the challenger lost as a challenger
 invariant {
-    description: "CB challenger lost the dispute game while challenging a state root",
+    description: "Challenger lost the dispute game while challenging a state root",
     condition: (Len { sequence: addressesInTrace } > 0) ? (Len { sequence: resolveEvents } == 0 ? true : !challengerLost) : true
 };
 
-// Invariant to trigger an alert if the CB challenger lost as a defender
+// Invariant to trigger an alert if the challenger lost as a defender
 invariant {
-    description: "CB challenger lost the dispute game while defending a state root",
+    description: "Challenger lost the dispute game while defending a state root",
     condition: (Len { sequence: addressesInTrace } > 0) ? (Len { sequence: resolveEvents } == 0 ? true : !defenderLost) : true
 };
 
-// Invariant to trigger an alert if CB Challenger lost any subgames
+// Invariant to trigger an alert if Challenger lost any subgames
 invariant {
-    description: "CB challenger lost one or more subgames",
+    description: "Challenger lost one or more subgames",
     condition: (Len { sequence: addressesInTrace } > 0) ? (!Contains { sequence: lostSubgames, item: true }) : true
 };

--- a/monitors/eth_deficit.gate
+++ b/monitors/eth_deficit.gate
@@ -1,7 +1,7 @@
 use Call from hexagate;
 
 param disputeGame: address;
-param cbChallenger: address;
+param honestChallenger: address;
 
 // Get the delayedWETH address for the particular dispute game
 source delayedWETH: address = Call {
@@ -9,18 +9,18 @@ source delayedWETH: address = Call {
     signature: "function weth() returns(address)"
 };
 
-// Get the credit due to the CB challenger from the dispute game
+// Get the credit due to the honest challenger from the dispute game
 source claimCredit: integer = Call {
     contract: disputeGame,
     signature: "function credit(address) returns (uint256)",
-    params: tuple(cbChallenger)
+    params: tuple(honestChallenger)
 };
 
-// Get the total credit amount set to be unlocked for the CB challenger from DelayedWETH
+// Get the total credit amount set to be unlocked for the honest challenger from DelayedWETH
 source totalCredit: tuple<integer,integer> = Call {
     contract: delayedWETH,
     signature: "function withdrawals(address game, address recipient) returns (uint256 amount, uint256 timestamp)",
-    params: tuple(disputeGame, cbChallenger)
+    params: tuple(disputeGame, honestChallenger)
 };
 
 // Get the balance of ETH for the disputeGame address in DelayedWETH

--- a/tests/challenged_proposal_test.go
+++ b/tests/challenged_proposal_test.go
@@ -14,9 +14,9 @@ func TestChallengedProposalChallengerAttacksRootClaim(t *testing.T) {
 
 	// set the params, which DO matter for these tests
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -35,7 +35,7 @@ func TestChallengedProposalChallengerAttacksRootClaim(t *testing.T) {
 		"claimData": [][]interface{}{
 			// the root claim doesn't have a real parent index since it is the root, so the index is type(uint32).max
 			{4294967295, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
-			// root claim is being attacked by the CB challenger
+			// root claim is being attacked by the honest challenger
 			{0, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 2, 123456},
 			{1, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 3, 123456},
 			{2, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 4, 1233456},
@@ -66,9 +66,9 @@ func TestChallengedProposalChallengerDefendsRootClaim(t *testing.T) {
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -86,7 +86,7 @@ func TestChallengedProposalChallengerDefendsRootClaim(t *testing.T) {
 		"claimData": [][]interface{}{
 			{4294967295, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
 			{0, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 2, 123456},
-			// root claim is being defended by the CB challenger
+			// root claim is being defended by the honest challenger
 			{1, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 3, 123456},
 			{2, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 4, 1233456},
 		},
@@ -111,15 +111,15 @@ func TestChallengedProposalChallengerDefendsRootClaim(t *testing.T) {
 	}
 }
 
-func TestChallengedProposalChallengerNotCB(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the challenger is not CB, regardless of
-	// whether the root claim submitted by CB proposer is challenged or not
+func TestChallengedProposalChallengerNotKnown(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the challenger is not the honest challenger, regardless of
+	// whether the root claim submitted by the honest proposer is challenged or not
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -162,15 +162,15 @@ func TestChallengedProposalChallengerNotCB(t *testing.T) {
 	}
 }
 
-func TestChallengedProposalProposerNotCB(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the proposer is not CB, regardless of
+func TestChallengedProposalProposerNotKnown(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the proposer is not the honest proposer, regardless of
 	// whether the challenger attacks the root claim or not
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -186,9 +186,9 @@ func TestChallengedProposalProposerNotCB(t *testing.T) {
 		},
 		"claimCount": 4,
 		"claimData": [][]interface{}{
-			// root claim is NOT proposed by the CB proposer
+			// root claim is NOT proposed by the honest proposer
 			{4294967295, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 1, 123456},
-			// root claim is challenged by the CB challenger
+			// root claim is challenged by the honest challenger
 			{0, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 2, 123456},
 			{1, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 3, 123456},
 			{2, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 4, 1233456},
@@ -219,9 +219,9 @@ func TestChallengedProposalOnlyRootClaim(t *testing.T) {
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -267,9 +267,9 @@ func TestChallengedProposalNoMoveEventInBlock(t *testing.T) {
 
 	// set the params, which DO matter for these tests
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
-		"cbChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestProposer":   "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"honestChallenger": "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4",
 	}
 
 	// read in the gate file
@@ -285,7 +285,7 @@ func TestChallengedProposalNoMoveEventInBlock(t *testing.T) {
 		"claimData": [][]interface{}{
 			// the root claim doesn't have a real parent index since it is the root, so the index is type(uint32).max
 			{4294967295, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
-			// root claim is being attacked by the CB challenger
+			// root claim is being attacked by the honest challenger
 			{0, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 2, 123456},
 			{1, "0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000", 1, "0x00", 3, 123456},
 			{2, "0x0000000000000000000000000000000000000000", "0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4", 1, "0x00", 4, 1233456},

--- a/tests/challenger_loses_test.go
+++ b/tests/challenger_loses_test.go
@@ -10,13 +10,13 @@ var (
 	monitorThirteenFile = "challenger_loses.gate"
 )
 
-func TestCbChallengerLostTopLevelChallenge(t *testing.T) {
-	// We expect an alert to be fired if the cb challenger was challenging a root claim and the claim resolved in favor of the defenders
+func TestChallengerLostTopLevelChallenge(t *testing.T) {
+	// We expect an alert to be fired if the honest challenger was challenging a root claim and the claim resolved in favor of the defenders
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -32,8 +32,8 @@ func TestCbChallengerLostTopLevelChallenge(t *testing.T) {
 			{2}, // resolution status of the dispute game, 2 = DEFENDER_WINS
 		},
 		"historicalMoveEvents": [][]interface{}{
-			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger attacks root claim
-			{1, "0x01", "0x00000000000000000000000000000000000000AA"}, // defender moves against cb challenger
+			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // challenger attacks root claim
+			{1, "0x01", "0x00000000000000000000000000000000000000AA"}, // defender moves against challenger
 		},
 		"claimCount": 3, // 3 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
@@ -64,7 +64,7 @@ func TestCbChallengerLostTopLevelChallenge(t *testing.T) {
 		t.Errorf("Monitor did not fire an alert for %s when it was supposed to", monitorThirteenFile)
 	}
 
-	expectedAlert := "CB challenger lost the dispute game while challenging a state root"
+	expectedAlert := "Challenger lost the dispute game while challenging a state root"
 	foundAlert := false
 	// we expect to see the specific alert fired
 	for _, alert := range failed {
@@ -82,13 +82,13 @@ func TestCbChallengerLostTopLevelChallenge(t *testing.T) {
 	}
 }
 
-func TestCbChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
-	// We expect an alert to be fired if the cb challenger was defending a root claim and the claim resolved in favor of the other challengers
+func TestChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
+	// We expect an alert to be fired if the honest challenger was defending a root claim and the claim resolved in favor of the other challengers
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -105,8 +105,8 @@ func TestCbChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
 		},
 		"historicalMoveEvents": [][]interface{}{
 			{0, "0x00", "0x00000000000000000000000000000000000000AA"}, // attacker challenges root claim
-			{1, "0x01", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger defends root claim by challenging the attacker's claim
-			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges cb challenger's claim
+			{1, "0x01", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // challenger defends root claim by challenging the attacker's claim
+			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges honest challenger's claim
 		},
 		"claimCount": 4, // 4 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
@@ -114,7 +114,7 @@ func TestCbChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
 			{11111111, "0x00000000000000000000000000000000000000AA", "0x00000000000000000000000000000000000000BB", 0, "0x00", 0, 123455},
 			// attacker claim was not countered
 			{0, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 1, "0x11", 1, 123456},
-			// cb challenger defense move was countered
+			// honest challenger defense move was countered
 			{1, "0x00000000000000000000000000000000000000AA", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 2, "0x22", 2, 123457},
 			// attacker claim was not countered
 			{2, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 3, "0x33", 3, 123458},
@@ -139,7 +139,7 @@ func TestCbChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
 		t.Errorf("Monitor did not fire an alert for %s when it was supposed to", monitorThirteenFile)
 	}
 
-	expectedAlert := "CB challenger lost the dispute game while defending a state root"
+	expectedAlert := "Challenger lost the dispute game while defending a state root"
 	foundAlert := false
 	// we expect to see the specific alert fired
 	for _, alert := range failed {
@@ -157,13 +157,13 @@ func TestCbChallengerLostTopLevelDefenseAndSubgame(t *testing.T) {
 	}
 }
 
-func TestCbChallengerLostSubgames(t *testing.T) {
-	// We expect an alert to be fired when the CB challenger loses any subgame claim, even if the top-level game was won
+func TestChallengerLostSubgames(t *testing.T) {
+	// We expect an alert to be fired when the honest challenger loses any subgame claim, even if the top-level game was won
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -180,9 +180,9 @@ func TestCbChallengerLostSubgames(t *testing.T) {
 		},
 		"historicalMoveEvents": [][]interface{}{
 			{0, "0x00", "0x00000000000000000000000000000000000000AA"}, // attacker challenges root claim
-			{1, "0x1a", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger defends root claim by challenging the attacker's claim
-			{1, "0x1b", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger (unrealistically) defends the root claim again on the same claim index
-			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges one of cb challenger's claim
+			{1, "0x1a", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // challenger defends root claim by challenging the attacker's claim
+			{1, "0x1b", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // challenger (unrealistically) defends the root claim again on the same claim index
+			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges one of the honest challenger's claim
 		},
 		"claimCount": 5, // 5 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
@@ -190,11 +190,11 @@ func TestCbChallengerLostSubgames(t *testing.T) {
 			{11111111, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000BB", 0, "0x00", 0, 123455},
 			// attacker claim on root claim is countered
 			{0, "0x49277EE36A024120Ee218127354c4a3591dc90A9", "0x00000000000000000000000000000000000000AA", 1, "0x33", 1, 123456},
-			// cb challenger first defense move is uncountered
+			// challenger first defense move is uncountered
 			{1, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 2, "0x11", 2, 123457},
-			// cb challenger second defense move was countered
+			// challenger second defense move was countered
 			{1, "0x00000000000000000000000000000000000000AA", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 2, "0x22", 2, 123458},
-			// attacker claim on cb challenger's second defense move was not countered
+			// attacker claim on honest challenger's second defense move was not countered
 			{2, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 3, "0x33", 3, 123459},
 		},
 	}
@@ -217,7 +217,7 @@ func TestCbChallengerLostSubgames(t *testing.T) {
 		t.Errorf("Monitor did not fire an alert for %s when it was supposed to", monitorThirteenFile)
 	}
 
-	expectedAlert := "CB challenger lost one or more subgames"
+	expectedAlert := "Challenger lost one or more subgames"
 	foundAlert := false
 	// we expect to see the specific alert fired
 	for _, alert := range failed {
@@ -235,13 +235,13 @@ func TestCbChallengerLostSubgames(t *testing.T) {
 	}
 }
 
-func TestCbChallengerWins(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the CB challenger wins all the claims it makes
+func TestChallengerWins(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the honest challenger wins all the claims it makes
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -257,13 +257,13 @@ func TestCbChallengerWins(t *testing.T) {
 			{1}, // resolution status of the dispute game, 1 = CHALLENGER_WINS
 		},
 		"historicalMoveEvents": [][]interface{}{
-			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger attacks root claim
+			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // honest hallenger attacks root claim
 		},
 		"claimCount": 2, // 2 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
-			// root claim was countered by cb challenger
+			// root claim was countered by the honest challenger
 			{11111111, "0x49277EE36A024120Ee218127354c4a3591dc90A9", "0x00000000000000000000000000000000000000AA", 0, "0x00", 0, 123455},
-			// cb challenger claim was not countered
+			// challenger claim was not countered
 			{0, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
 		},
 	}
@@ -287,13 +287,13 @@ func TestCbChallengerWins(t *testing.T) {
 	}
 }
 
-func TestCbChallengerGameInProgress(t *testing.T) {
+func TestChallengerGameInProgress(t *testing.T) {
 	// We DO NOT expect an alert to be fired when the dispute game is still in progress
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -309,7 +309,7 @@ func TestCbChallengerGameInProgress(t *testing.T) {
 			{0}, // resolution status of the dispute game, 0 = IN_PROGRESS
 		},
 		"historicalMoveEvents": [][]interface{}{
-			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger attacks root claim
+			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // honest challenger attacks root claim
 		},
 		"claimCount": 2, // 2 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
@@ -338,13 +338,13 @@ func TestCbChallengerGameInProgress(t *testing.T) {
 	}
 }
 
-func TestCbChallengerLostTopLevelChallengeNoFilterAddress(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the CB challenger loses a top-level challenge and there is no filtered address
+func TestChallengerLostTopLevelChallengeNoFilterAddress(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the honest challenger loses a top-level challenge and there is no filtered address
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -359,14 +359,14 @@ func TestCbChallengerLostTopLevelChallengeNoFilterAddress(t *testing.T) {
 			{2}, // resolution status of the dispute game, 2 = DEFENDER_WINS
 		},
 		"historicalMoveEvents": [][]interface{}{
-			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger attacks root claim
-			{1, "0x01", "0x00000000000000000000000000000000000000AA"}, // defender moves against cb challenger
+			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // honest challenger attacks root claim
+			{1, "0x01", "0x00000000000000000000000000000000000000AA"}, // defender moves against the honest challenger
 		},
 		"claimCount": 3, // 3 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
 			// root claim was not countered
 			{11111111, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 0, "0x00", 0, 123455},
-			// cb challenger claim was countered successfully
+			// challenger claim was countered successfully
 			{0, "0x00000000000000000000000000000000000000AA", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
 			// defender claim was also not countered
 			{1, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 2, "0x00", 2, 123457},
@@ -392,13 +392,13 @@ func TestCbChallengerLostTopLevelChallengeNoFilterAddress(t *testing.T) {
 	}
 }
 
-func TestCbChallengerLostTopLevelDefenseAndSubgameNoFilterAddress(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the CB challenger loses a top-level defense and subgame and there is no filtered address
+func TestChallengerLostTopLevelDefenseAndSubgameNoFilterAddress(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the honest challenger loses a top-level defense and subgame and there is no filtered address
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -414,8 +414,8 @@ func TestCbChallengerLostTopLevelDefenseAndSubgameNoFilterAddress(t *testing.T) 
 		},
 		"historicalMoveEvents": [][]interface{}{
 			{0, "0x00", "0x00000000000000000000000000000000000000AA"}, // attacker challenges root claim
-			{1, "0x01", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger defends root claim by challenging the attacker's claim
-			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges cb challenger's claim
+			{1, "0x01", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // honest challenger defends root claim by challenging the attacker's claim
+			{2, "0x02", "0x00000000000000000000000000000000000000AA"}, // attacker challenges the honest challenger's claim
 		},
 		"claimCount": 4, // 4 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
@@ -423,7 +423,7 @@ func TestCbChallengerLostTopLevelDefenseAndSubgameNoFilterAddress(t *testing.T) 
 			{11111111, "0x00000000000000000000000000000000000000AA", "0x00000000000000000000000000000000000000BB", 0, "0x00", 0, 123455},
 			// attacker claim was not countered
 			{0, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 1, "0x11", 1, 123456},
-			// cb challenger defense move was countered
+			// challenger defense move was countered
 			{1, "0x00000000000000000000000000000000000000AA", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 2, "0x22", 2, 123457},
 			// attacker claim was not countered
 			{2, "0x0000000000000000000000000000000000000000", "0x00000000000000000000000000000000000000AA", 3, "0x33", 3, 123458},
@@ -449,13 +449,13 @@ func TestCbChallengerLostTopLevelDefenseAndSubgameNoFilterAddress(t *testing.T) 
 	}
 }
 
-func TestCbChallengerLostSubgamesNoFilterAddress(t *testing.T) {
-	// We DO NOT expect an alert to be fired when the CB challenger loses any subgame claim and there is no filtered address
+func TestChallengerLostSubgamesNoFilterAddress(t *testing.T) {
+	// We DO NOT expect an alert to be fired when the honest challenger loses any subgame claim and there is no filtered address
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
 	}
 
 	// read in the gate file
@@ -470,13 +470,13 @@ func TestCbChallengerLostSubgamesNoFilterAddress(t *testing.T) {
 			{1}, // resolution status of the dispute game, 1 = CHALLENGER_WINS
 		},
 		"historicalMoveEvents": [][]interface{}{
-			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // cb challenger attacks root claim
+			{0, "0x00", "0x49277EE36A024120Ee218127354c4a3591dc90A9"}, // honest challenger attacks root claim
 		},
 		"claimCount": 2, // 2 claims total, inclusive of the root claim which doesn't count as a Move
 		"claimResults": [][]interface{}{
 			// root claim was countered by cb challenger
 			{11111111, "0x49277EE36A024120Ee218127354c4a3591dc90A9", "0x00000000000000000000000000000000000000AA", 0, "0x00", 0, 123455},
-			// cb challenger claim was not countered
+			// challenger claim was not countered
 			{0, "0x0000000000000000000000000000000000000000", "0x49277EE36A024120Ee218127354c4a3591dc90A9", 1, "0x00", 1, 123456},
 		},
 	}

--- a/tests/eth_deficit_test.go
+++ b/tests/eth_deficit_test.go
@@ -14,8 +14,8 @@ func TestETHDeficitTotalCreditDeficit(t *testing.T) {
 
 	// set the params, which don't really matter for these tests
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x0000000000000000000000000000000000000000",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x0000000000000000000000000000000000000000",
 	}
 
 	// read in the gate file
@@ -56,8 +56,8 @@ func TestETHDeficitTotalETHBalanceDeficit(t *testing.T) {
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x0000000000000000000000000000000000000000",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x0000000000000000000000000000000000000000",
 	}
 
 	// read in the gate file
@@ -98,8 +98,8 @@ func TestETHDeficitCurrCreditZeroTotalCreditNonZero(t *testing.T) {
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x0000000000000000000000000000000000000000",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x0000000000000000000000000000000000000000",
 	}
 
 	// read in the gate file
@@ -140,8 +140,8 @@ func TestETHDeficitNoDeficit(t *testing.T) {
 
 	// set the params
 	params := map[string]any{
-		"disputeGame":  "0x0000000000000000000000000000000000000000",
-		"cbChallenger": "0x0000000000000000000000000000000000000000",
+		"disputeGame":      "0x0000000000000000000000000000000000000000",
+		"honestChallenger": "0x0000000000000000000000000000000000000000",
 	}
 
 	// read in the gate file


### PR DESCRIPTION
Updated the parameters to be more generic in the following monitors:

- challenged_proposal
- challenger_loses
- eth_deficit

Ultimately the parameters would have functioned correctly regardless, so long as a user configures them with values that make sense. However this just makes the names more generic to avoid confusion. I updated the docs + tests as well and checked that the tests still pass.