### PR TITLE
Fix hasUnlockedCredit in Eth Deficit

### DIFF
--- a/monitors/eth_deficit.gate
+++ b/monitors/eth_deficit.gate
@@ -63,7 +63,7 @@ invariant {
     //   - The honest challenger's totalCredit cannot be non-zero if their credit is zero
     description: "Deficit of ETH in DelayedWETH contract",
     condition: bondDistributionMode == 0 ? true : // Skip if mode undecided
-        hasUnlockedCredit
+        (hasUnlockedCredit or creditBalanceToCheck == 0)
         and (creditBalanceToCheck <= totalCredit[0])
         and (totalCredit[0] <= ethBalanceDisputeGame)
         and !(creditBalanceToCheck == 0 and totalCredit[0] != 0)


### PR DESCRIPTION
Updated `hasUnlockedCredit` to `(hasUnlockedCredit or creditBalanceToCheck == 0)` to handle scenarios where the honest challenger has no bonds to unlock due to inactivity in the dispute game.